### PR TITLE
Add `iconoir-react-native` v1.0.0 publication date to CHANGELOG

### DIFF
--- a/packages/iconoir-react-native/CHANGELOG.md
+++ b/packages/iconoir-react-native/CHANGELOG.md
@@ -6,6 +6,6 @@ npm package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - TBD
+## [1.0.0] - 2021-06-19
 ### Added
 - Initial release of `iconoir-react-native` to npm. Based on iconoir `v4.3.1`.


### PR DESCRIPTION
Very simple PR. Just adding publication date to the CHANGELOG in the `iconoir-react-native` package.