### PR TITLE
Release v2.0.1 of 'iconoir-react-native' without bundled 'react-native-svg'

### DIFF
--- a/packages/iconoir-react-native/CHANGELOG.md
+++ b/packages/iconoir-react-native/CHANGELOG.md
@@ -6,6 +6,10 @@ npm package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2021-06-28
+### Fixed
+- Don't bundle 'react-native-svg', fixes #54
+
 ## [1.0.0] - 2021-06-19
 ### Added
 - Initial release of `iconoir-react-native` to npm. Based on iconoir `v4.3.1`.

--- a/packages/iconoir-react-native/README.md
+++ b/packages/iconoir-react-native/README.md
@@ -12,11 +12,11 @@ Iconoir is an open source library with 900+ SVG Icons. No premium icons, no emai
 ### Installation
 
 ```
-yarn add iconoir-react-native
+yarn add iconoir-react-native react-native-svg
 ```
 or
 ```
-npm i iconoir-react-native
+npm i iconoir-react-native react-native-svg
 ```
 
 ### Usage

--- a/packages/iconoir-react-native/package-lock.json
+++ b/packages/iconoir-react-native/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "iconoir-react-native",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -293,9 +293,9 @@
       "dev": true
     },
     "esbuild": {
-      "version": "0.11.23",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.11.23.tgz",
-      "integrity": "sha512-iaiZZ9vUF5wJV8ob1tl+5aJTrwDczlvGP0JoMmnpC2B0ppiMCu8n8gmy5ZTGl5bcG081XBVn+U+jP+mPFm5T5Q==",
+      "version": "0.12.11",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.11.tgz",
+      "integrity": "sha512-h83GwI6lYOrnSv5hSY2i2XZ191v3haj2IGDzwrkfWHhuO/kVMX3RYjhwRNG9E5VSxVLPaUjTVwrv8HWLvhk2nQ==",
       "dev": true
     },
     "execa": {
@@ -316,17 +316,16 @@
       }
     },
     "fast-glob": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
-      "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.6.tgz",
+      "integrity": "sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.0",
+        "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.2",
-        "picomatch": "^2.2.1"
+        "micromatch": "^4.0.4"
       }
     },
     "fastq": {
@@ -742,9 +741,9 @@
       "dev": true
     },
     "rollup": {
-      "version": "2.52.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.52.1.tgz",
-      "integrity": "sha512-/SPqz8UGnp4P1hq6wc9gdTqA2bXQXGx13TtoL03GBm6qGRI6Hm3p4Io7GeiHNLl0BsQAne1JNYY+q/apcY933w==",
+      "version": "2.52.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.52.3.tgz",
+      "integrity": "sha512-QF3Sju8Kl2z0osI4unyOLyUudyhOMK6G0AeqJWgfiyigqLAlnNrfBcDWDx+f1cqn+JU2iIYVkDrgQ6/KtwEfrg==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -799,9 +798,9 @@
       "dev": true
     },
     "sucrase": {
-      "version": "3.18.2",
-      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.18.2.tgz",
-      "integrity": "sha512-xCFP35OA6uAtBUVB8jPSftiR2Udjh0d9JkQnUOYppILpN4rBSk0yxiy67GVzD3XsFGIB6LlyIfhCABtwlopMSw==",
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.19.0.tgz",
+      "integrity": "sha512-FeMelydANPRMiOo/lxbf7NxN8bQmMVBQmKOa69BifwVhteMJzRoJNHaVBoCYmE/kpnx6VPg9ckaLumwtuAzmEA==",
       "dev": true,
       "requires": {
         "commander": "^4.0.0",
@@ -861,16 +860,16 @@
       "dev": true
     },
     "tsup": {
-      "version": "4.11.2",
-      "resolved": "https://registry.npmjs.org/tsup/-/tsup-4.11.2.tgz",
-      "integrity": "sha512-cp+gy0TGzFm/3PkPNeiZ2Fvi4MKI8jj6Xq6gVpSQ+Og+6GPqfws2K4zYo11OJoccuk2LnlJIJt8xwnoYCVGpSA==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-4.12.0.tgz",
+      "integrity": "sha512-TjODlDrJYcMHW8nRVbhf2PBelo2ew3s7zfSdp/17dXlPkMbnYs80ZmITPgR1KRa6cagSqU+9lYZZe/xbRqhWAQ==",
       "dev": true,
       "requires": {
         "cac": "^6.7.2",
         "chalk": "^4.1.0",
         "chokidar": "^3.5.1",
         "debug": "^4.3.1",
-        "esbuild": "^0.11.12",
+        "esbuild": "^0.12.9",
         "execa": "^5.0.0",
         "globby": "^11.0.3",
         "joycon": "^3.0.1",
@@ -882,9 +881,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.3.tgz",
-      "integrity": "sha512-rUvLW0WtF7PF2b9yenwWUi9Da9euvDRhmH7BLyBG4DCFfOJ850LGNknmRpp8Z8kXNUPObdZQEfKOiHtXuQHHKA==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
+      "integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
       "dev": true
     },
     "which": {

--- a/packages/iconoir-react-native/package.json
+++ b/packages/iconoir-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iconoir-react-native",
-  "version": "1.0.0",
+  "version": "2.0.1",
   "description": "React Native library for Iconoir icon set",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",
@@ -27,15 +27,16 @@
   "homepage": "https://github.com/lucaburgio/iconoir#readme",
   "peerDependencies": {
     "react": "^16.8.6 || ^17",
-    "react-native": ">=0.50.0"
+    "react-native": ">=0.50.0",
+    "react-native-svg": "^12.1.1"
   },
   "devDependencies": {
     "@babel/runtime": "^7.14.6",
     "@types/react": "^17.0.11",
     "react": "^17.0.2",
     "react-native-svg": "^12.1.1",
-    "tsup": "^4.11.2",
-    "typescript": "^4.3.3"
+    "tsup": "^4.12.0",
+    "typescript": "^4.3.4"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
Fixes #54 