### PR TITLE
support webpack treeshaking

### DIFF
--- a/packages/iconoir-react-native/package.json
+++ b/packages/iconoir-react-native/package.json
@@ -35,7 +35,8 @@
     "@types/react": "^17.0.11",
     "react": "^17.0.2",
     "react-native-svg": "^12.1.1",
-    "tsup": "^4.11.2",
-    "typescript": "^4.3.3"
-  }
+    "tsup": "^4.12.0",
+    "typescript": "^4.3.4"
+  },
+  "dependencies": {}
 }

--- a/packages/iconoir-react-native/package.json
+++ b/packages/iconoir-react-native/package.json
@@ -9,7 +9,7 @@
     "dist"
   ],
   "scripts": {
-    "dist": "tsup"
+    "dist": "tsup && tsc"
   },
   "repository": {
     "type": "git",
@@ -24,6 +24,7 @@
   "bugs": {
     "url": "https://github.com/lucaburgio/iconoir/issues"
   },
+  "sideEffects": false,
   "homepage": "https://github.com/lucaburgio/iconoir#readme",
   "peerDependencies": {
     "react": "^16.8.6 || ^17",
@@ -36,6 +37,5 @@
     "react-native-svg": "^12.1.1",
     "tsup": "^4.11.2",
     "typescript": "^4.3.3"
-  },
-  "dependencies": {}
+  }
 }

--- a/packages/iconoir-react-native/tsconfig.json
+++ b/packages/iconoir-react-native/tsconfig.json
@@ -8,6 +8,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist/esm"
   }
 }

--- a/packages/iconoir-react-native/tsup.config.json
+++ b/packages/iconoir-react-native/tsup.config.json
@@ -1,6 +1,6 @@
 {
   "entryPoints": ["src/index.tsx"],
-  "format": ["cjs", "esm"],
+  "format": ["cjs"],
   "legacyOutput": true,
   "sourcemap": true,
   "minify": true,

--- a/packages/iconoir-react/package.json
+++ b/packages/iconoir-react/package.json
@@ -9,7 +9,7 @@
     "dist"
   ],
   "scripts": {
-    "dist": "tsup"
+    "dist": "tsup && tsc"
   },
   "repository": {
     "type": "git",
@@ -24,6 +24,7 @@
   "bugs": {
     "url": "https://github.com/lucaburgio/iconoir/issues"
   },
+  "sideEffects": false,
   "homepage": "https://github.com/lucaburgio/iconoir#readme",
   "peerDependencies": {
     "react": "^16.8.6 || ^17"

--- a/packages/iconoir-react/tsconfig.json
+++ b/packages/iconoir-react/tsconfig.json
@@ -8,6 +8,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist/esm"
   }
 }

--- a/packages/iconoir-react/tsup.config.json
+++ b/packages/iconoir-react/tsup.config.json
@@ -1,6 +1,6 @@
 {
   "entryPoints": ["src/index.tsx"],
-  "format": ["cjs", "esm"],
+  "format": ["cjs"],
   "legacyOutput": true,
   "sourcemap": true,
   "minify": true,


### PR DESCRIPTION
This would build the package in a way that webpack is able to tree-shake the code. This reduces the bundle size from the whole 60kb (minified + gzipped) to only the size of the icons imported into the application code.