### PR TITLE
ci: delete the tag first so we can overwrite it

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,6 +29,7 @@ jobs:
     - run: pnpm run prepublish
       env:
         TAG_NAME: ${{ github.ref_name }}
+    - run: git tag -d ${{ github.ref_name }} # We need to delete the tag in order to overwrite it.
     - uses: stefanzweifel/git-auto-commit-action@v4
       with:
         commit_message: Release Version


### PR DESCRIPTION
It looks like the Action just failed because we were trying to overwrite the existing tag (which I thought I accounted for with the `--force` push option, but it appears not).

So instead we have to delete the tag, and then immediately re-create it, and then push that tag.