### PR TITLE
feat: add support for ESM modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint": "eslint ./bin/build.js",
     "lint:fix": "npm run lint -- --fix",
     "build": "node ./bin/build.js",
-    "prepublish": "node ./bin/prepublish.js"
+    "prepublish": "node ./bin/prepublish.js",
+    "dist": "pnpm m --filter ./packages run dist"
   },
   "repository": {
     "type": "git",

--- a/packages/iconoir-react-native/package.json
+++ b/packages/iconoir-react-native/package.json
@@ -4,11 +4,12 @@
   "description": "React Native library for Iconoir icon set",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],
   "scripts": {
-    "dist": "tsc",
+    "dist": "tsc -p tsconfig.json && tsc -p tsconfig.esm.json",
     "prepublish": "npm run dist"
   },
   "repository": {

--- a/packages/iconoir-react-native/tsconfig.esm.json
+++ b/packages/iconoir-react-native/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "outDir": "./dist/esm"
+  }
+}

--- a/packages/iconoir-react/package.json
+++ b/packages/iconoir-react/package.json
@@ -4,11 +4,12 @@
   "description": "React library for Iconoir icon set",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],
   "scripts": {
-    "dist": "tsc",
+    "dist": "tsc -p tsconfig.json && tsc -p tsconfig.esm.json",
     "prepublish": "npm run dist"
   },
   "repository": {

--- a/packages/iconoir-react/tsconfig.esm.json
+++ b/packages/iconoir-react/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "outDir": "./dist/esm"
+  }
+}


### PR DESCRIPTION
Resolves https://github.com/lucaburgio/iconoir/pull/132#issuecomment-1075345365﻿

This PR just adds a new `module` entry to `package.json` for both `iconoir-react` and `iconoir-react-native` to allow Webpack / other bundlers to import the ESM versions instead of CommonJS, so they do a better job of tree shaking.

The existing CommonJS code is not touched inside the `dist` folder, so anyone importing specific icons from the CommonJS code should not be affected.