### PR TITLE
feat: support auto-publishing the core iconoir package as well

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
         version: 6.27.1
         run_install: true
     - run: pnpm run build
-    - run: pnpm run prepublish
+    - run: pnpm run prepublish-all
       env:
         TAG_NAME: ${{ github.ref_name }}
     - uses: stefanzweifel/git-auto-commit-action@v4
@@ -37,6 +37,9 @@ jobs:
         branch: master
     - run: git -c user.email="actions@github.com" -c user.name="GitHub Actions" tag -fa ${{ github.ref_name }} -m "${{ github.ref_name }}"
     - run: git push -f origin ${{ github.ref_name }}
+    - run: npm publish --access public
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     - run: pnpm -r publish --filter ./packages --access public
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/bin/prepublish.js
+++ b/bin/prepublish.js
@@ -13,7 +13,10 @@ function publishPackage(name) {
     throw new Error(`Tag name ${process.env.TAG_NAME} is not valid.`);
   }
 
-  const packageJsonPath = path.join('packages', name, 'package.json');
+  const packageJsonPath =
+    name === 'iconoir'
+      ? 'package.json'
+      : path.join('packages', name, 'package.json');
   const contents = JSON.parse(fs.readFileSync(packageJsonPath).toString());
   contents.version = newVersion;
   if (PACKAGE_BASE) {
@@ -23,5 +26,6 @@ function publishPackage(name) {
   console.info('package.json updated');
 }
 
+publishPackage('iconoir');
 publishPackage('iconoir-react');
 publishPackage('iconoir-react-native');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iconoir",
-  "version": "4.6.0",
+  "version": "4.9.0",
   "description": "A Simple and Definitive Open-Source Icons Library",
   "type": "module",
   "files": [
@@ -11,7 +11,7 @@
     "lint": "eslint ./bin/build.js",
     "lint:fix": "npm run lint -- --fix",
     "build": "node ./bin/build.js",
-    "prepublish": "node ./bin/prepublish.js",
+    "prepublish-all": "node ./bin/prepublish.js",
     "dist": "pnpm m --filter ./packages run dist"
   },
   "repository": {


### PR DESCRIPTION
Resolves #139

Adds the core `iconoir` package to the auto-publish scripts, so it should be automatically published with each new release as well. The core `iconoir` package contains all of the CSS and SVG assets, as it does today.