### PR TITLE
chore: Allow react 18 as peer dependency

### DIFF
--- a/packages/iconoir-react-native/package.json
+++ b/packages/iconoir-react-native/package.json
@@ -29,7 +29,7 @@
   "sideEffects": false,
   "homepage": "https://iconoir.com",
   "peerDependencies": {
-    "react": "^16.8.6 || ^17",
+    "react": "^16.8.6 || ^17 || ^18",
     "react-native": ">=0.50.0",
     "react-native-svg": "^12.1.1"
   },

--- a/packages/iconoir-react/package.json
+++ b/packages/iconoir-react/package.json
@@ -29,7 +29,7 @@
   "sideEffects": false,
   "homepage": "https://iconoir.com",
   "peerDependencies": {
-    "react": "^16.8.6 || ^17"
+    "react": "^16.8.6 || ^17 || ^18"
   },
   "devDependencies": {
     "@types/react": "^17.0.29",


### PR DESCRIPTION
I have been using iconoir in a react@18 project and so far it worked well. Thus, I think it should be fine to add it into the peer dependency allow list. It would remove some peer mismatch warning from package manager :)